### PR TITLE
Fix exit code when no signal caught

### DIFF
--- a/bin/mocha.js
+++ b/bin/mocha.js
@@ -118,7 +118,7 @@ if (mochaArgs['node-option'] || Object.keys(nodeArgs).length || hasInspect) {
           process.kill(process.pid, signal);
         }
       } else {
-        process.exit(code);
+        process.exit((mochaArgs['posix-exit-codes'] === true) ? 0 : code);
       }
     });
   });

--- a/test/integration/options/posixExitCodes.spec.js
+++ b/test/integration/options/posixExitCodes.spec.js
@@ -42,5 +42,17 @@ describe('--posix-exit-codes', function () {
         done();
       });
     });
+
+    it('should exit with the number of failed tests', function (done) {
+      var fixture = 'failing.fixture.js'; // one failing test
+      var args = ['--no-warnings'];
+      runMocha(fixture, args, function postmortem(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res.code, 'to be', 1);
+        done();
+      });
+    });
   });
 });

--- a/test/integration/options/posixExitCodes.spec.js
+++ b/test/integration/options/posixExitCodes.spec.js
@@ -4,7 +4,7 @@ var helpers = require('../helpers');
 var runMocha = helpers.runMocha;
 
 describe('--posix-exit-codes', function () {
-  describe('when enabled with node options', function () {
+  describe('when enabled, and with node options', function () {
     var args = ['--no-warnings', '--posix-exit-codes'];
 
     it('should exit with code 134 on SIGABRT', function (done) {
@@ -28,9 +28,20 @@ describe('--posix-exit-codes', function () {
         done();
       });
     });
+
+    it('should exit with code 0 even if there are test failures', function (done) {
+      var fixture = 'failing.fixture.js';
+      runMocha(fixture, args, function postmortem(err, res) {
+        if (err) {
+          return done(err);
+        }
+        expect(res.code, 'to be', 0);
+        done();
+      });
+    });
   });
 
-  describe('when not enabled with node options', function () {
+  describe('when not enabled, and with node options', function () {
     it('should exit with code null on SIGABRT', function (done) {
       var fixture = 'signals-sigabrt.fixture.js';
       var args = ['--no-warnings'];


### PR DESCRIPTION
This PR addresses comments on https://github.com/mochajs/mocha/pull/4989 by fixing the exit code in the following scenario:

 - if "--posix-exit-codes" is specified in the command-line options:
   - if no signal is caught
     - exit with code 0
   - otherwise exit with 128 + numerical signal

The PR also adds test coverage to assert that the original behavior of exiting with the number of failed tests continues to work the same way when "--posix-exit-codes" is not specified in the command line options.