### PR TITLE
Support posix-exit-codes for child and in-process modes

### DIFF
--- a/bin/mocha.js
+++ b/bin/mocha.js
@@ -25,7 +25,7 @@ const mochaArgs = {};
 const nodeArgs = {};
 const EXIT_SUCCESS = 0;
 const EXIT_FAILURE = 1;
-const SIGNAL_OFFSET= 128;
+const SIGNAL_OFFSET = 128;
 let hasInspect = false;
 
 const opts = loadOptions(process.argv.slice(2));

--- a/lib/cli/run-helpers.js
+++ b/lib/cli/run-helpers.js
@@ -16,6 +16,7 @@ const {format} = require('util');
 const {createInvalidLegacyPluginError} = require('../errors');
 const {requireOrImport} = require('../nodejs/esm-utils');
 const PluginLoader = require('../plugin-loader');
+const EXIT_FAILURE = 1;
 
 /**
  * Exits Mocha when tests + code under test has finished execution (default)
@@ -25,7 +26,10 @@ const PluginLoader = require('../plugin-loader');
  */
 const exitMochaLater = code => {
   process.on('exit', () => {
-    process.exitCode = Math.min(code, 255);
+    const usePosixExitCodes = process.argv.includes('--posix-exit-codes');
+    const exitCode =
+      usePosixExitCodes && code > 0 ? EXIT_FAILURE : Math.min(code, 255);
+    process.exitCode = exitCode;
   });
 };
 
@@ -37,7 +41,9 @@ const exitMochaLater = code => {
  * @private
  */
 const exitMocha = code => {
-  const clampedCode = Math.min(code, 255);
+  const usePosixExitCodes = process.argv.includes('--posix-exit-codes');
+  const clampedCode =
+    usePosixExitCodes && code > 0 ? EXIT_FAILURE : Math.min(code, 255);
   let draining = 0;
 
   // Eagerly set the process's exit code in case stream.write doesn't

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -7,6 +7,7 @@ const {format} = require('util');
 const path = require('path');
 const Base = require('../../lib/reporters/base');
 const debug = require('debug')('mocha:test:integration:helpers');
+const SIGNAL_OFFSET = 128;
 
 /**
  * Path to `mocha` executable
@@ -355,6 +356,18 @@ function createSubprocess(args, done, opts = {}) {
       args,
       command: args.join(' ')
     });
+  });
+
+  /**
+   * Emulate node's exit code for fatal signal. Allows tests to see the same
+   * exit code as the mocha cli.
+   */
+  mocha.on('exit', (code, signal) => {
+    if (signal) {
+      mocha.exitCode =
+        SIGNAL_OFFSET +
+        (typeof signal == 'string' ? os.constants.signals[signal] : signal);
+    }
   });
 
   return mocha;

--- a/test/integration/options/posixExitCodes.spec.js
+++ b/test/integration/options/posixExitCodes.spec.js
@@ -9,9 +9,10 @@ const EXIT_FAILURE = 1;
 const SIGNAL_OFFSET = 128;
 
 describe('--posix-exit-codes', function () {
-  if (os.platform() !== 'win32') { // SIGTERM is not supported on Windows
-    describe('when enabled, and with node options', function () {
-      var args = ['--no-warnings', '--posix-exit-codes'];
+  describe('when enabled', function () {
+    describe('when mocha is run as a child process', () => {
+      // 'no-warnings' node option makes mocha run as a child process
+      const args = ['--no-warnings', '--posix-exit-codes'];
 
       it('should exit with correct POSIX shell code on SIGABRT', function (done) {
         var fixture = 'signals-sigabrt.fixture.js';
@@ -19,20 +20,33 @@ describe('--posix-exit-codes', function () {
           if (err) {
             return done(err);
           }
-          expect(res.code, 'to be', SIGNAL_OFFSET + os.constants.signals.SIGABRT);
+          expect(
+            res.code,
+            'to be',
+            SIGNAL_OFFSET + os.constants.signals.SIGABRT
+          );
           done();
         });
       });
 
       it('should exit with correct POSIX shell code on SIGTERM', function (done) {
-        var fixture = 'signals-sigterm.fixture.js';
-        runMocha(fixture, args, function postmortem(err, res) {
-          if (err) {
-            return done(err);
-          }
-          expect(res.code, 'to be', SIGNAL_OFFSET + os.constants.signals.SIGTERM);
+        // SIGTERM is not supported on Windows
+        if (os.platform() !== 'win32') {
+          var fixture = 'signals-sigterm.fixture.js';
+          runMocha(fixture, args, function postmortem(err, res) {
+            if (err) {
+              return done(err);
+            }
+            expect(
+              res.code,
+              'to be',
+              SIGNAL_OFFSET + os.constants.signals.SIGTERM
+            );
+            done();
+          });
+        } else {
           done();
-        });
+        }
       });
 
       it('should exit with code 1 if there are test failures', function (done) {
@@ -46,19 +60,158 @@ describe('--posix-exit-codes', function () {
         });
       });
     });
-  }
 
-  describe('when not enabled, and with node options', function () {
-    it('should exit with the number of failed tests', function (done) {
-      var fixture = 'failing.fixture.js'; // contains three failing tests
-      var numFailures = 3;
-      var args = ['--no-warnings'];
-      runMocha(fixture, args, function postmortem(err, res) {
-        if (err) {
-          return done(err);
+    describe('when mocha is run in-process', () => {
+      // Without node-specific cli options, mocha runs in-process
+      const args = ['--posix-exit-codes'];
+
+      it('should exit with the correct POSIX shell code on SIGABRT', function (done) {
+        var fixture = 'signals-sigabrt.fixture.js';
+        runMocha(fixture, args, function postmortem(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(
+            res.code,
+            'to be',
+            SIGNAL_OFFSET + os.constants.signals.SIGABRT
+          );
+          done();
+        });
+      });
+
+      it('should exit with the correct POSIX shell code on SIGTERM', function (done) {
+        // SIGTERM is not supported on Windows
+        if (os.platform() !== 'win32') {
+          var fixture = 'signals-sigterm.fixture.js';
+          runMocha(fixture, args, function postmortem(err, res) {
+            if (err) {
+              return done(err);
+            }
+            expect(
+              res.code,
+              'to be',
+              SIGNAL_OFFSET + os.constants.signals.SIGTERM
+            );
+            done();
+          });
+        } else {
+          done();
         }
-        expect(res.code, 'to be', numFailures);
-        done();
+      });
+
+      it('should exit with code 1 if there are test failures', function (done) {
+        var fixture = 'failing.fixture.js';
+        runMocha(fixture, args, function postmortem(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.code, 'to be', EXIT_FAILURE);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('when not enabled', function () {
+    const fixture = 'failing.fixture.js'; // contains three failing tests
+    const numFailures = 3;
+
+    describe('when mocha is run as a child process', () => {
+      // 'no-warnings' node option makes mocha run as a child process
+      var args = ['--no-warnings'];
+
+      it('should exit with the correct POSIX shell code on SIGABRT', function (done) {
+        var fixture = 'signals-sigabrt.fixture.js';
+        runMocha(fixture, args, function postmortem(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(
+            res.code,
+            'to be',
+            SIGNAL_OFFSET + os.constants.signals.SIGABRT
+          );
+          done();
+        });
+      });
+
+      it('should exit with the correct POSIX shell code on SIGTERM', function (done) {
+        // SIGTERM is not supported on Windows
+        if (os.platform() !== 'win32') {
+          var fixture = 'signals-sigterm.fixture.js';
+          runMocha(fixture, args, function postmortem(err, res) {
+            if (err) {
+              return done(err);
+            }
+            expect(
+              res.code,
+              'to be',
+              SIGNAL_OFFSET + os.constants.signals.SIGTERM
+            );
+            done();
+          });
+        } else {
+          done();
+        }
+      });
+
+      it('should exit with the number of failed tests', function (done) {
+        runMocha(fixture, args, function postmortem(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.code, 'to be', numFailures);
+          done();
+        });
+      });
+    });
+
+    describe('when mocha is run in-process', () => {
+      var args = [];
+      it('should exit with the correct POSIX shell code on SIGABRT', function (done) {
+        var fixture = 'signals-sigabrt.fixture.js';
+        runMocha(fixture, args, function postmortem(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(
+            res.code,
+            'to be',
+            SIGNAL_OFFSET + os.constants.signals.SIGABRT
+          );
+          done();
+        });
+      });
+
+      it('should exit with the correct POSIX shell code on SIGTERM', function (done) {
+        // SIGTERM is not supported on Windows
+        if (os.platform() !== 'win32') {
+          var fixture = 'signals-sigterm.fixture.js';
+          runMocha(fixture, args, function postmortem(err, res) {
+            if (err) {
+              return done(err);
+            }
+            expect(
+              res.code,
+              'to be',
+              SIGNAL_OFFSET + os.constants.signals.SIGTERM
+            );
+            done();
+          });
+        } else {
+          done();
+        }
+      });
+
+      it('should exit with the number of failed tests', function (done) {
+        runMocha(fixture, args, function postmortem(err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.code, 'to be', numFailures);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
## Overview

Mocha has two ways of running: as a child process or in the main process. If there are any _node_ command-line options (with or without _mocha_ command line options) it will spawn a child process to run mocha and pass the node-specific options to that child process.

Reviewers of our PR to the upstream mocha repository requested that the `--posix-exit-codes` option should be supported in both modes of operation (mocha as a child process AND mocha in the main process). Originally I had it only working for mocha as a child process because that satisfies our use-case where we run mocha via `nyc` which passes node-specific options.

This PR also adds some additional unit tests to round out the coverage for these four scenarios:
  - posix exit codes with mocha as a child process
  - posix exit codes with mocha in the main process
  - normal exit codes with mocha as a child process
  - normal exit codes with mocha in the main process

Note that in ALL cases, when a fatal signal (ie. SIGABRT, SIGTERM) kills the mocha process, the exit code should now be [128 + numeric value of signal] in compliance with standard posix & bash command behaviour.